### PR TITLE
Support native callbacks

### DIFF
--- a/bridge.c
+++ b/bridge.c
@@ -1,5 +1,6 @@
 #include <memory.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <libjsonnet.h>
 #include "bridge.h"
@@ -16,4 +17,33 @@ char* CallImport_cgo(void *ctx, const char *base, const char *rel, char **found_
   char* buf = jsonnet_realloc(vm, NULL, strlen(result)+1);
   strcpy(buf, result);
   return buf;
+}
+
+
+// This function is bound for every native callback, but with a different context.
+JsonnetJsonValuePtr CallNative_cgo(void *ctx, const JsonnetJsonValuePtr const *argv, int *success) {
+  struct JsonnetVm* vm = ctx;
+  // Currently support only a single string parameter.
+  const char* params = jsonnet_json_extract_string(vm, argv[0]);
+  char* result = go_call_native(ctx, (char *)params, success);
+
+  return jsonnet_json_make_string(vm, result);
+}
+
+// The following are helpers for converting a Go slice of strings
+// into an array of null terminated strings.
+char** makeCharArray(int size) {
+  return calloc(size, sizeof(char*));
+}
+
+void setArrayString(char **a, char *s, int n) {
+  a[n] = s;
+}
+
+void freeCharArray(char **a, int size) {
+  int i;
+  for (i = 0; i < size; i++) {
+    free(a[i]);
+  }
+  free(a);
 }

--- a/bridge.c
+++ b/bridge.c
@@ -42,7 +42,9 @@ JsonnetJsonValuePtr CallNative_cgo(void *ctx, const JsonnetJsonValuePtr const *a
   free(params);
 
   // Currently the return value can be a plain string value.
-  return jsonnet_json_make_string(context->vm, result);
+  JsonnetJsonValuePtr json_result = jsonnet_json_make_string(context->vm, result);
+  free(result);
+  return json_result;
 }
 
 // The following are helpers for converting a Go slice of strings

--- a/bridge.h
+++ b/bridge.h
@@ -16,7 +16,7 @@ JsonnetJsonValuePtr CallNative_cgo(void *ctx, const JsonnetJsonValuePtr const *a
 
 char* go_call_import(void* vm, char *base, char *rel, char **path, int *success);
 
-char* go_call_native(void* native_context, char *argv, int *success);
+char* go_call_native(void* native_context, char **argv, int *success);
 
 // The following are helpers for converting a Go slice of strings
 // into an array of null terminated strings.

--- a/bridge.h
+++ b/bridge.h
@@ -4,10 +4,26 @@
 
 typedef JsonnetImportCallback* JsonnetImportCallbackPtr;
 
+typedef JsonnetNativeCallback* JsonnetNativeCallbackPtr;
+
+typedef struct JsonnetJsonValue* JsonnetJsonValuePtr;
+
 struct JsonnetVm* go_get_guts(void* ctx);
 
 char* CallImport_cgo(void *ctx, const char *base, const char *rel, char **found_here, int *success);
 
+JsonnetJsonValuePtr CallNative_cgo(void *ctx, const JsonnetJsonValuePtr const *argv, int *succes);
+
 char* go_call_import(void* vm, char *base, char *rel, char **path, int *success);
+
+char* go_call_native(void* native_context, char *argv, int *success);
+
+// The following are helpers for converting a Go slice of strings
+// into an array of null terminated strings.
+char** makeCharArray(int size);
+
+void setArrayString(char **a, char *s, int n);
+
+void freeCharArray(char **a, int size);
 
 #endif

--- a/jsonnet.go
+++ b/jsonnet.go
@@ -24,9 +24,18 @@ import (
 
 type ImportCallback func(base, rel string) (result string, path string, err error)
 
+type NativeCallback func(params string) (result string, err error)
+
 type VM struct {
 	guts           *C.struct_JsonnetVm
 	importCallback ImportCallback
+}
+
+// NativeContext contains the data required for the generic CallNative_cgo function
+// to be able to call a specific go callback.
+type NativeContext struct {
+	vm             *C.struct_JsonnetVm
+	nativeCallback NativeCallback
 }
 
 //export go_call_import
@@ -38,6 +47,19 @@ func go_call_import(vmPtr unsafe.Pointer, base, rel *C.char, pathPtr **C.char, o
 		return C.CString(err.Error())
 	}
 	*pathPtr = C.CString(path)
+	*okPtr = C.int(1)
+	return C.CString(result)
+}
+
+//export go_call_native
+func go_call_native(nativeContextPtr unsafe.Pointer, params *C.char, okPtr *C.int) *C.char {
+	nativeContext := (*NativeContext)(nativeContextPtr)
+
+	result, err := nativeContext.nativeCallback(C.GoString(params))
+	if err != nil {
+		*okPtr = C.int(0)
+		return C.CString(err.Error())
+	}
 	*okPtr = C.int(1)
 	return C.CString(result)
 }
@@ -108,6 +130,23 @@ func (vm *VM) FormatSnippet(filename, snippet string) (string, error) {
 func (vm *VM) ImportCallback(f ImportCallback) {
 	vm.importCallback = f
 	C.jsonnet_import_callback(vm.guts, C.JsonnetImportCallbackPtr(C.CallImport_cgo), unsafe.Pointer(vm))
+}
+
+// Register a native callback.
+func (vm *VM) NativeCallback(func_name string, f NativeCallback, paramNames []string) {
+	// Convert the paramNames slice into a null-terminated
+	params := C.makeCharArray(C.int(len(paramNames)))
+	defer C.freeCharArray(params, C.int(len(paramNames)))
+	for i, s := range paramNames {
+		C.setArrayString(params, C.CString(s), C.int(i))
+	}
+
+	// When libjsonnet invokes CallNative_cgo, the following context will be passed
+	// so that the generic CallNative_cgo can call back to go_call_native which can
+	// call the registered native function.
+	native_context := NativeContext{vm.guts, f}
+
+	C.jsonnet_native_callback(vm.guts, C.CString(func_name), C.JsonnetNativeCallbackPtr(C.CallNative_cgo), unsafe.Pointer(&native_context), params)
 }
 
 // Bind a Jsonnet external var to the given value.

--- a/jsonnet_test.go
+++ b/jsonnet_test.go
@@ -263,8 +263,8 @@ func Test_NativeCallbackError(t *testing.T) {
 
 	result, err := vm.EvaluateSnippet("testfoo", data)
 
-	if result != "" {
-		t.Errorf("Unexpected result on error. Want: %q, Got: %q", "", result)
+	if got, want := result, ""; got != want {
+		t.Errorf("Unexpected result on error. Got: %q, Want: %q", got, want)
 	}
 
 	if err == nil {


### PR DESCRIPTION
This initial support allows native callbacks with the signature `func(params ...string) (string, error)` only.

This doesn't restrict input parameters too much, as you can include a parameter which is unmarshalled as valid JSON (see the extract_template example in the tests), but it does mean that the output can currently only be a string.